### PR TITLE
Convert `printf` to `echo` to fix leading --dash error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -43,6 +42,6 @@ function mac(str, fn) {
 // exec
 
 function execute(program, str, fn) {
-  var cmd = escape(['printf', str]) + ' | ' + program;
+  var cmd = escape(['echo', str]) + ' | ' + program;
   exec(cmd, fn || function(){});
 }


### PR DESCRIPTION
If you try to run this to copy an SSH key it fails for this reason:

http://threads.hpcl.gwu.edu/sites/guts/ticket/3

Changing it to `echo` seems to work.
