### PR TITLE
Fix for linux: populate the clipboard with xclip

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function windows(str, fn) {
 // linux
 
 function linux(str, fn) {
-  execute('xclip', str, fn);
+  execute('xclip -selection clipboard', str, fn);
 }
 
 // mac


### PR DESCRIPTION
There are at least 2 clipboards on Linux, the default one not being the one we want to use usually.

By default, the `primary selection` is populated with `xclip` (the one which is populated when we highlight text).
It's probably not the one we want as it can be erased easily if we highlight something else.