### PR TITLE
Support FreeBSD

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var os = require('os');
 // platforms
 
 switch (os.platform()) {
+  case 'freebsd': return module.exports = freebsd;
   case 'win': return module.exports = windows;
   case 'linux': return module.exports = linux;
   case 'darwin': return module.exports = mac;
@@ -20,6 +21,12 @@ switch (os.platform()) {
 
 function unsupported(str, fn) {
   fn(new Error('unsupported platform'));
+}
+
+// freebsd
+
+function freebsd(str, fn) {
+  execute('xsel -i -b', str, fn);
 }
 
 // windows


### PR DESCRIPTION
Almost architectures of FreeBSD have [`xsel`](http://portsmon.freebsd.org/portoverview.py?category=x11&portname=xsel) in Ports.

My machine is FreeBSD 11.0-CURRENT, and this works perfectly for me.