### PR TITLE
os.platform() returns 'win32' for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var os = require('os');
 
 switch (os.platform()) {
   case 'freebsd': return module.exports = freebsd;
-  case 'win': return module.exports = windows;
+  case 'win32': return module.exports = windows;
   case 'linux': return module.exports = linux;
   case 'darwin': return module.exports = mac;
   default: return module.exports = unsupported;


### PR DESCRIPTION
Solves #3. see [docs](https://nodejs.org/api/os.html#os_os_platform)
